### PR TITLE
ABCP20-12706 Added new method FilterByKeys

### DIFF
--- a/maps/maps.go
+++ b/maps/maps.go
@@ -33,3 +33,16 @@ func DiffKeys[K comparable, V any](a map[K]V, b map[K]V) map[K]V {
 
 	return result
 }
+
+// FilterByKeys returns a new map containing only elements with keys present in the keys slice.
+func FilterByKeys[K comparable, V any](m map[K]V, keys []K) map[K]V {
+	result := make(map[K]V, len(keys))
+
+	for _, key := range keys {
+		if v, ok := m[key]; ok {
+			result[key] = v
+		}
+	}
+
+	return result
+}

--- a/maps/maps_test.go
+++ b/maps/maps_test.go
@@ -121,3 +121,43 @@ func BenchmarkDiffKeys(b *testing.B) {
 		DiffKeys(a, bm)
 	}
 }
+
+func TestFilterByKeys(t *testing.T) {
+	m := map[int]string{1: "one", 2: "two", 3: "three", 4: "four", 5: "five"}
+
+	keys := []int{1, 3, 5}
+	expected := map[int]string{1: "one", 3: "three", 5: "five"}
+	result := FilterByKeys(m, keys)
+	assert.Equal(t, expected, result)
+
+	keys = []int{2, 4}
+	expected = map[int]string{2: "two", 4: "four"}
+	result = FilterByKeys(m, keys)
+	assert.Equal(t, expected, result)
+
+	keys = []int{10, 20}
+	expected = map[int]string{}
+	result = FilterByKeys(m, keys)
+	assert.Equal(t, expected, result)
+
+	keys = []int{}
+	expected = map[int]string{}
+	result = FilterByKeys(m, keys)
+	assert.Equal(t, expected, result)
+}
+
+func BenchmarkFilterByKeys(b *testing.B) {
+	m := make(map[int]string, 1000)
+	keys := make([]int, 100)
+	for i := 0; i < 1000; i++ {
+		m[i] = "value"
+		if i < 100 {
+			keys[i] = i
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		FilterByKeys(m, keys)
+	}
+}


### PR DESCRIPTION
Added the FilterByKeys method for filtering maps by slice keys.
Required for ABCP20-12706 (adding financial variables to OrderPickingLists Printed Forms).